### PR TITLE
perf: use reduce for chinese normalization

### DIFF
--- a/src/chinese.ts
+++ b/src/chinese.ts
@@ -4,11 +4,9 @@
  * @See https://ctext.org/faq/normalization
  */
 export const normalizeChinese = (input: string): string => {
-  let converted = '';
-  for (const ch of input) {
-    converted += CONVERSION_TABLE.get(ch) ?? ch;
-  }
-  return converted;
+  return input
+    .split('')
+    .reduce((acc, ch) => acc + CONVERSION_TABLE.get(ch) ?? ch, '');
 };
 
 // Conversion data listed on https://ctext.org/faq/normalization


### PR DESCRIPTION
was able to see up to 1.17x speed improvement on local environment ([deno](https://github.com/scarf005/normalize_cjk), V8).

```
$ deno bench
Check file:///home/scarf/repo/deno/normalize_cjk/chinese_bench.ts
cpu: AMD Ryzen 5 5600G with Radeon Graphics
runtime: deno 1.39.0+d51fda9 (x86_64-unknown-linux-gnu)

file:///home/scarf/repo/deno/normalize_cjk/chinese_bench.ts
benchmark               time (avg)        iter/s             (min … max)       p75       p99      p995
------------------------------------------------------------------------ -----------------------------
current (reduce)       134.98 ms/iter           7.4 (111.79 ms … 160.48 ms) 149.77 ms 160.48 ms 160.48 ms
original (forloop)     158.83 ms/iter           6.3 (137.35 ms … 187.01 ms) 166.98 ms 187.01 ms 187.01 ms

summary
  current (reduce)
   1.18x faster than original (forloop)
```